### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/modules/aircraft.py
+++ b/modules/aircraft.py
@@ -3,6 +3,7 @@
 '''
 classes for aircraft model
 '''
+from __future__ import print_function
 
 import time, struct, numpy
 from math import sin, cos, sqrt
@@ -114,8 +115,8 @@ class State(object):
                 int(v*m2cm), int(v*m2cm),
                 int(self.xacc*mpss2mg), int(self.yacc*mpss2mg), int(self.zacc*mpss2mg))
         except struct.error as e:
-            print e
-            print 'mav hil packet data exceeds int bounds?'
+            print(e)
+            print('mav hil packet data exceeds int bounds?')
 
 
     @classmethod

--- a/modules/gcs.py
+++ b/modules/gcs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/evn python
 
+from __future__ import print_function
 import time
 
 import pymavlink.mavwp as mavwp
@@ -18,18 +19,18 @@ class WaypointManager(object):
         self._transition_idle()
 
     def _transition_idle(self):
-        print 'transition idle'
+        print('transition idle')
         self.state = 'IDLE'
         self.index = -1
 
     def _transition_sending_count(self):
-        print 'transition sending count'
+        print('transition sending count')
         self.state = 'SENDING_COUNT'
         self.index = -1
         self.send_time = time.time()
 
     def _transition_sending_waypoint(self):
-        print 'transition sending waypoints'
+        print('transition sending waypoints')
         self.state = 'SENDING_WAYPOINT'
 
     def set_waypoints(self, waypoints):
@@ -47,7 +48,7 @@ class WaypointManager(object):
                 self.mavfile.waypoint_clear_all_send()
                 self.mavfile.waypoint_count_send(self.count)
                 self.mavfile.waypoint_count_send(self.count)
-                print "Sent waypoint count of %u" % self.count
+                print("Sent waypoint count of %u" % self.count)
 
         elif self.state == 'SENDING_WAYPOINT':
 
@@ -56,7 +57,7 @@ class WaypointManager(object):
                 wp = self.loader.wp(self.index)
                 self.mavfile.mav.send(wp)
                 self.mavfile.mav.send(wp)
-                print "Sent waypoint %u" % (self.index)
+                print("Sent waypoint %u" % (self.index))
 
                 # this seems to prompt vehicle to resend request
                 #self.mavfile.waypoint_count_send(self.count)
@@ -65,8 +66,8 @@ class WaypointManager(object):
     def process_msg(self, msg):
 
         if msg.get_type() == 'MISSION_REQUEST':
-            print 'received request for {0:d} from {1:d}:{2:d}'.format(
-                msg.seq, msg.get_srcSystem(),  msg.get_srcComponent())
+            print('received request for {0:d} from {1:d}:{2:d}'.format(
+                msg.seq, msg.get_srcSystem(),  msg.get_srcComponent()))
 
         # transition to sending waypoints as soon as mission request received
         if self.state == 'SENDING_COUNT':
@@ -81,9 +82,9 @@ class WaypointManager(object):
 
             if msg.get_type() == 'MISSION_ACK':
                 if self.index == self.count - 1:
-                    print "Waypoint uploading complete"
+                    print("Waypoint uploading complete")
                 else:
-                    print "Error: received waypoint ack before sending all waypoints!"
+                    print("Error: received waypoint ack before sending all waypoints!")
                 self._transition_idle()
 
             if msg.get_type() == 'MISSION_REQUEST':
@@ -92,8 +93,8 @@ class WaypointManager(object):
 
                 # should never exceed waypoint count
                 if msg.seq >  self.count - 1:
-                    print "Error: {0:d} waypoints, but waypoint {1:d} requested".format(
-                        self.count,msg.seq)
+                    print("Error: {0:d} waypoints, but waypoint {1:d} requested".format(
+                        self.count,msg.seq))
                     self._transition_idle()
                 elif msg.seq == self.index + 1:
                     self.index += 1

--- a/modules/hangar.py
+++ b/modules/hangar.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import time
 
 import aircraft
@@ -117,7 +118,7 @@ class BasicAircraft(object):
         t_now = time.time()
         if t_now - self.t_out > 1:
             self.t_out = t_now
-            print 'imu {0:4d} Hz, gps {1:4d} Hz\n'.format(
-                self.imu_count, self.gps_count)
+            print('imu {0:4d} Hz, gps {1:4d} Hz\n'.format(
+                self.imu_count, self.gps_count))
             self.gps_count = 0
             self.imu_count = 0

--- a/runhil.py
+++ b/runhil.py
@@ -3,6 +3,7 @@
 '''
 runs hil simulation
 '''
+from __future__ import print_function
 
 # system import
 import sys, struct, time, os, argparse, signal, math, errno, psutil
@@ -91,7 +92,7 @@ class SensorHIL(object):
 
 
     def __del__(self):
-        print 'SensorHil shutting down'
+        print('SensorHil shutting down')
         # JSBSim really doesn't like to die ...
         if self.jsb_console is not None:
             self.jsb_console.send('quit\n')
@@ -104,12 +105,12 @@ class SensorHIL(object):
 
         # master
         master = mavutil.mavserial(master_dev, baud=baudrate, autoreconnect=True)
-        print 'master connected on device: ', master_dev
+        print('master connected on device: ', master_dev)
 
         # gcs
         if gcs_dev is not None:
             gcs = mavutil.mavudp(gcs_dev, input=False)
-            print 'gcs connected on device: ', gcs_dev
+            print('gcs connected on device: ', gcs_dev)
 
         # class data
         self.master = master
@@ -268,14 +269,14 @@ class SensorHIL(object):
             while not shutdown:
                 self.set_hil_and_arm()
                 #self.set_mode_flag(mavlink.MAV_MODE_FLAG_HIL_ENABLED, True)
-                print 'Sending reboot to autopilot'
+                print('Sending reboot to autopilot')
                 self.master.reboot_autopilot()
                 # wait for heartbeat timeout, continue looping if not received
                 shutdown = self.wait_for_no_msg(msg='HEARTBEAT', period=2, timeout=10)
-            print 'Autopilot heartbeat lost (rebooting)'
+            print('Autopilot heartbeat lost (rebooting)')
             # Try to read heartbeat three times before restarting shutdown
             for i in range(3):
-                print 'Attempt %d to read autopilot heartbeat.' % (i+1)
+                print('Attempt %d to read autopilot heartbeat.' % (i+1))
                 # Reset serial comm
                 self.master.reset()
                 reboot_successful = self.wait_for_msg('HEARTBEAT', timeout=100)
@@ -293,7 +294,7 @@ class SensorHIL(object):
     def reset_sim(self):
 
         if self.jsb is not None:
-            print 'quitting jsbsim'
+            print('quitting jsbsim')
             self.jsb.close(force=True)
             self.jsb_out.close()
             self.jsb_in.close()
@@ -313,7 +314,7 @@ class SensorHIL(object):
         self.jsb.expect("\(Trim\) executed")
         self.jsb_console.send('hold\n')
 
-        print 'load waypoints'
+        print('load waypoints')
         if not self.waypoints is None:
             self.wpm.set_waypoints(self.waypoints)
             self.wpm.send_waypoints()
@@ -329,7 +330,7 @@ class SensorHIL(object):
         self.ac.send_state(self.master.mav)
         # send initial data for estimators to work and system to be able to
         # switch to autonomous mode
-        print 'sending sensor data'
+        print('sending sensor data')
         time_start = time.time()
         #while time.time() - time_start < 5:
         while time.time() - time_start < 4:
@@ -365,7 +366,7 @@ class SensorHIL(object):
                         raise
         else:
             self.jsbsim_bad_packet  += 1
-            print 'jsbsim bad packets: ', self.jsbsim_bad_packet
+            print('jsbsim bad packets: ', self.jsbsim_bad_packet)
 
     @staticmethod
     def interpret_address(addrstr):
@@ -398,7 +399,7 @@ class SensorHIL(object):
             self.ac.send_controls(self.jsb_console)
 
         elif mtype == 'STATUSTEXT':
-            print 'sys %d: %s' % (self.master.target_system, m.text)
+            print('sys %d: %s' % (self.master.target_system, m.text))
 
         # handle waypoint messages
         self.wpm.process_msg(m)
@@ -414,7 +415,7 @@ class SensorHIL(object):
                 self.gcs.auto_mavlink_version(buf)
             msgs = self.gcs.mav.parse_buffer(buf)
         except mavutil.mavlink.MAVError as e:
-            print "Bad MAVLink gcs message from %s: %s" % (slave.address, e.message)
+            print("Bad MAVLink gcs message from %s: %s" % (slave.address, e.message))
             return
         if msgs is None:
             return
@@ -464,15 +465,15 @@ class SensorHIL(object):
 
         dt_report = time.time() - self.last_report
         if dt_report > 5:
-            print '\nmode: {0:X}, JSBSim {1:5.0f} Hz, {2:d} sent, {3:d} received, {4:d} errors, bwin={5:.1f} kB/s, bwout={6:.1f} kB/s'.format(
+            print('\nmode: {0:X}, JSBSim {1:5.0f} Hz, {2:d} sent, {3:d} received, {4:d} errors, bwin={5:.1f} kB/s, bwout={6:.1f} kB/s'.format(
                 self.master.base_mode,
                 self.frame_count/dt_report,
                 self.master.mav.total_packets_sent,
                 self.master.mav.total_packets_received,
                 self.master.mav.total_receive_errors,
                 0.001*(self.master.mav.total_bytes_received-self.bytes_recv)/dt_report,
-                0.001*(self.master.mav.total_bytes_sent-self.bytes_sent)/dt_report)
-            print self.counts
+                0.001*(self.master.mav.total_bytes_sent-self.bytes_sent)/dt_report))
+            print(self.counts)
             self.bytes_sent = self.master.mav.total_bytes_sent
             self.bytes_recv = self.master.mav.total_bytes_received
             self.frame_count = 0


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.